### PR TITLE
Build path to irb using dirname of FileUtils::RUBY

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ end
 irb = proc do |env|
   ENV['RACK_ENV'] = env
   trap('INT', "IGNORE")
-  sh "#{FileUtils::RUBY.sub('ruby', 'irb')} -r ./models"
+  sh "#{File.join(File.dirname(FileUtils::RUBY), 'irb')} -r ./models"
 end
 
 desc "Open irb shell in test mode"


### PR DESCRIPTION
Fix instances where `ruby` exists inside the path outside of the bin name, causing the `sub` method to replace the wrong instance of `ruby`.

ie. `/Users/username/.rubies/ruby-2.3.1/bin/ruby`