### PR TITLE
Add Sass explicitly to the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rack_csrf'
+gem 'sass'
 gem 'tilt', '>= 2'
 gem 'erubi'
 gem 'roda', '>= 3'


### PR DESCRIPTION
Hey @jeremyevans !

Love everything you're doing. I tried to fire this guy up and hit the dreaded

```
LoadError: cannot load such file -- sass
```

Adding Sass explicitly to the `Gemfile` solved it.

Thanks!
-Tyler
