### PR TITLE
Fix FrozenError when starting server in production environment

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -17,6 +17,6 @@ unless dev
   rescue LoadError
   else
     require 'tilt/sass' unless File.exist?(File.expand_path('../compiled_assets.json', __FILE__))
-    Refrigerator.freeze_core
+    Refrigerator.freeze_core(:except=>['Object'])
   end
 end


### PR DESCRIPTION
Current configuration raises `FrozenError: can't modify frozen #<Class:Object>` when starting server in production environment with Ruby 2.5.x or Ruby 2.6.x. Excluding `Object` from `Refrigerator.freeze_core` will fix the error.

#### Webrick
```
$ bundle exec rackup -s webrick
bundler: failed to load command: rackup (/home/exampleuser/projects/exampleapp/releases/1/vendor/bundle/ruby/2.6.0/bin/rackup)
FrozenError: can't modify frozen #<Class:Object>
  /opt/rubies/ruby-2.6.2/lib/ruby/2.6.0/erb.rb:261:in `<top (required)>'
  /home/exampleuser/projects/exampleapp/shared/vendor/bundle/ruby/2.6.0/gems/rack-2.0.7/lib/rack/show_exceptions.rb:2:in `require'
  /home/exampleuser/projects/exampleapp/shared/vendor/bundle/ruby/2.6.0/gems/rack-2.0.7/lib/rack/show_exceptions.rb:2:in `<top (required)>'
  /home/exampleuser/projects/exampleapp/shared/vendor/bundle/ruby/2.6.0/gems/rack-2.0.7/lib/rack/server.rb:241:in `require'

```

#### Puma
```
$ bundle exec puma
bundler: failed to load command: puma (/home/exampleuser/projects/exampleapp/releases/1/vendor/bundle/ruby/2.6.0/bin/puma)
FrozenError: can't modify frozen #<Class:Object>
  /opt/rubies/ruby-2.6.2/lib/ruby/2.6.0/psych/versions.rb:3:in `<top (required)>'
  /opt/rubies/ruby-2.6.2/lib/ruby/2.6.0/psych.rb:2:in `require'
  /opt/rubies/ruby-2.6.2/lib/ruby/2.6.0/psych.rb:2:in `<top (required)>'
  /opt/rubies/ruby-2.6.2/lib/ruby/2.6.0/yaml.rb:4:in `require'
  /opt/rubies/ruby-2.6.2/lib/ruby/2.6.0/yaml.rb:4:in `<top (required)>'
  /home/exampleuser/projects/exampleapp/shared/vendor/bundle/ruby/2.6.0/gems/puma-3.12.1/lib/puma/state_file.rb:3:in `require'
```