### PR TITLE
Change the annotate task to work with sub-directories

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -102,7 +102,7 @@ task "annotate" do
   require_relative 'models'
   DB.loggers.clear
   require 'sequel/annotate'
-  Sequel::Annotate.annotate(Dir['models/*.rb'])
+  Sequel::Annotate.annotate(Dir['models/**/*.rb'])
 end
 
 last_line = __LINE__


### PR DESCRIPTION
One change I keep making to this template is changing the annotate task to find and annotate models in sub-directories within the model directory. Comes up often enough I can imagine others might benefit and I don't see a downside to making this the default behavior.